### PR TITLE
Normalize users directory URL to follow current domain

### DIFF
--- a/PJSIP_lib/microsip/settings.h
+++ b/PJSIP_lib/microsip/settings.h
@@ -160,6 +160,7 @@ struct AccountSettings {
 	void AccountSave(int id, Account *account);
 	void AccountDelete(int id);
 	void SettingsSave();
+	void EnsureUsersDirectoryTemplate();
 };
 
 extern AccountSettings accountSettings;


### PR DESCRIPTION
## Summary
- add a normalization helper for the users directory URL so the WONIT agenda endpoint keeps the dynamic domain placeholder
- apply the normalization when loading and saving settings to automatically refresh the URL after domain changes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc4b0ac534832b852a96e14c612a26