### PR TITLE
Ensure users directory URL uses current account domain

### DIFF
--- a/PJSIP_lib/microsip/settings.cpp
+++ b/PJSIP_lib/microsip/settings.cpp
@@ -32,6 +32,82 @@ bool pj_ready;
 CTime startTime;
 CArray<Shortcut, Shortcut> shortcuts;
 
+namespace {
+
+static LPCTSTR const kWonitUsersDirectoryTemplate = _T("http://{domain}/api/wonit/agenda?token=oXg069kEHYugjb2wAbsUOc&favorito=true&status=true");
+static LPCTSTR const kWonitUsersDirectorySuffix = _T("/api/wonit/agenda?token=oXg069kEHYugjb2wAbsUOc&favorito=true&status=true");
+
+CString NormalizeUsersDirectory(const CString &value, const CString &accountDomain)
+{
+	CString directory = value;
+	directory.Trim();
+
+	CString domain = accountDomain;
+	domain.Trim();
+
+	if (directory.IsEmpty()) {
+		if (domain.IsEmpty()) {
+			return CString(kWonitUsersDirectoryTemplate);
+		}
+		CString url;
+		url.Format(_T("http://%s%s"), domain, kWonitUsersDirectorySuffix);
+		url.Trim();
+		return url;
+	}
+
+	if (!domain.IsEmpty()) {
+		if (directory.Find(_T("{domain}")) != -1) {
+			CString normalized = directory;
+			normalized.Replace(_T("{domain}"), domain);
+			normalized.Trim();
+			return normalized;
+		}
+
+		CString suffix(kWonitUsersDirectorySuffix);
+		CString suffixLower(suffix);
+		suffixLower.MakeLower();
+
+		CString directoryLower(directory);
+		directoryLower.MakeLower();
+
+		if (directoryLower.Right(suffixLower.GetLength()) == suffixLower) {
+			int suffixPos = directory.GetLength() - suffix.GetLength();
+			CString prefix = directory.Left(suffixPos);
+			CString prefixLower = directoryLower.Left(suffixPos);
+
+			int schemeLength = 0;
+			if (prefixLower.Left(8) == _T("https://")) {
+				schemeLength = 8;
+			}
+			else if (prefixLower.Left(7) == _T("http://")) {
+				schemeLength = 7;
+			}
+
+			int domainStart = schemeLength;
+			int atPos = prefix.ReverseFind(_T('@'));
+			if (atPos != -1 && atPos + 1 > domainStart) {
+				domainStart = atPos + 1;
+			}
+
+			CString currentDomain = prefix.Mid(domainStart);
+			CString currentDomainLower = currentDomain;
+			currentDomainLower.MakeLower();
+			CString desiredDomainLower = domain;
+			desiredDomainLower.MakeLower();
+
+			if (currentDomain.IsEmpty() || currentDomainLower != desiredDomainLower) {
+				CString beforeDomain = prefix.Left(domainStart);
+				CString updated = beforeDomain + domain + suffix;
+				updated.Trim();
+				return updated;
+			}
+		}
+	}
+
+	return directory;
+}
+} // namespace
+
 static LONGLONG FileSize(const wchar_t* name)
 {
 	WIN32_FILE_ATTRIBUTE_DATA fad;
@@ -470,8 +546,9 @@ void AccountSettings::Init()
 
 	//--
 	ptr = usersDirectory.GetBuffer(255);
-	GetPrivateProfileString(section, _T("usersDirectory"), NULL, ptr, 256, iniFile);
+	GetPrivateProfileString(section, _T("usersDirectory"), kWonitUsersDirectoryTemplate, ptr, 256, iniFile);
 	usersDirectory.ReleaseBuffer();
+	EnsureUsersDirectoryTemplate();
 
 	ptr = defaultAction.GetBuffer(255);
 	GetPrivateProfileString(section, _T("defaultAction"), NULL, ptr, 256, iniFile);
@@ -785,6 +862,7 @@ void AccountSettings::Init()
 			}
 		}
 	}
+	EnsureUsersDirectoryTemplate();
 	AccountLoad(0, &accountLocal);
 }
 
@@ -1013,6 +1091,8 @@ void AccountSettings::SettingsSave()
 	str.Format(_T("%d"), accountId);
 	WritePrivateProfileString(section, _T("accountId"), str, iniFile);
 
+	EnsureUsersDirectoryTemplate();
+
 // save user settings
 
 	WritePrivateProfileString(section, _T("singleMode"), singleMode ? _T("1") : _T("0"), iniFile);
@@ -1186,6 +1266,11 @@ void AccountSettings::SettingsSave()
 	WritePrivateProfileString(section, _T("shortcutsBottom"), shortcutsBottom ? _T("1") : _T("0"), iniFile);
 	WritePrivateProfileString(section, _T("lastCallNumber"), lastCallNumber, iniFile);
 	WritePrivateProfileString(section, _T("lastCallHasVideo"), lastCallHasVideo ? _T("1") : _T("0"), iniFile);
+}
+
+void AccountSettings::EnsureUsersDirectoryTemplate()
+{
+	usersDirectory = NormalizeUsersDirectory(usersDirectory, account.domain);
 }
 
 CString ShortcutEncode(Shortcut *pShortcut)

--- a/PJSIP_lib/microsip/settings.h
+++ b/PJSIP_lib/microsip/settings.h
@@ -160,6 +160,7 @@ struct AccountSettings {
 	void AccountSave(int id, Account *account);
 	void AccountDelete(int id);
 	void SettingsSave();
+	void EnsureUsersDirectoryTemplate();
 };
 
 extern AccountSettings accountSettings;


### PR DESCRIPTION
## Summary
- update the users directory normalization helper to substitute the current account domain while preserving scheme and credentials when rebuilding the WONIT URL
- rerun the normalization after loading account settings so the stored URL refreshes as soon as the account domain changes
- make AccountSettings::EnsureUsersDirectoryTemplate pass the loaded account domain to the normalization helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc4b0ac534832b852a96e14c612a26